### PR TITLE
feat: Add validate as a subcommand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tf-policy-validator"
-version = "0.0.3"
+version = "0.0.4"
 description = "A command line tool that validates AWS IAM Policies in a Terraform template against AWS IAM best practices"
 authors = ["Policy Validator Maintainers <terraform-policy-validator@amazon.com>"]
 readme = "README.md"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add validate as a subcommand similar to cfn-policy-validator
https://github.com/awslabs/aws-cloudformation-iam-policy-validator/blob/main/cfn_policy_validator/main.py

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
