### PR TITLE
Add specific finding codes to a block list to give greater control

### DIFF
--- a/iam_check/lib/reporter.py
+++ b/iam_check/lib/reporter.py
@@ -20,6 +20,7 @@ class Reporter:
 		self.nonblocking_findings = []
 		self.findings_to_ignore = findings_to_ignore
 		self.finding_types_that_are_blocking = finding_types_that_are_blocking
+		self.finding_codes_that_are_blocking = finding_codes_that_are_blocking
 		self.allowed_external_principals = allowed_external_principals
 
 	def build_report_from(self, findings):
@@ -65,6 +66,8 @@ class Reporter:
 			return
 
 		if finding.findingType.upper() in self.finding_types_that_are_blocking:
+			self.blocking_findings.append(finding)
+		elif '.'.join([finding.findingType.upper(), finding.code.upper()]) in self.finding_types_that_are_blocking:
 			self.blocking_findings.append(finding)
 		else:
 			self.nonblocking_findings.append(finding)

--- a/iam_check/lib/reporter.py
+++ b/iam_check/lib/reporter.py
@@ -20,7 +20,6 @@ class Reporter:
 		self.nonblocking_findings = []
 		self.findings_to_ignore = findings_to_ignore
 		self.finding_types_that_are_blocking = finding_types_that_are_blocking
-		self.finding_codes_that_are_blocking = finding_codes_that_are_blocking
 		self.allowed_external_principals = allowed_external_principals
 
 	def build_report_from(self, findings):


### PR DESCRIPTION

*Description of changes:*
Certain suggestions, warnings, etc might be considered "blocking" internally whereas Access Analyzer only considers them suggestions. 

I don't want to block on all SUGGESTION findings but there are some SUGGESTION codes that I do want to block on, specifically: SUGGESTION.ALLOW_WITH_UNSUPPORTED_TAG_CONDITION_KEY_FOR_SERVICE

Many teams try to build policies with condition tags that don't work with the service and do something like this pseudo policy: 

Action: kinesis:*
Resource: *
Condition: Tags Must Include <something> 

This gets flagged as a suggestion but actually grants full Kinesis:* to the policy, despite the user wanting to scope permissions down. 

By blocking on this specific suggestion code, the user is protected from over permissive policy actions that they didn't intend on granting themselves.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
