### PR TITLE
Fix InvalidInput error in iam_check/doc/example_report_3.md

### DIFF
--- a/iam_check/doc/example_report_3.md
+++ b/iam_check/doc/example_report_3.md
@@ -7,13 +7,16 @@ terraform {
 data "aws_iam_policy_document" "demo_bucket_policy" {
   statement {
     sid = "ListBucket"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
     effect = "Allow"
     actions = [
       "s3:ListBuckets"
     ]
     resources = ["*"]
   }
-
 }
 
 resource "aws_s3_bucket_policy" "demo_bucket_policy" {
@@ -25,12 +28,12 @@ resource "aws_s3_bucket_policy" "demo_bucket_policy" {
 ***commands***
 ```bash
 $ terraform init
-$ terraform plan -out tf.plan 
+$ terraform plan -out tf.plan
 $ terraform show -json -no-color tf.plan > tf.json
 
 $ python3 -m pip install pipenv
-$ pipenv install 
-$ pipenv run python iam_check/iam_check.py --config iam_check/config/default.yaml --template-path tf.json --region us-east-1 
+$ pipenv install
+$ pipenv run python iam_check/iam_check.py --config iam_check/config/default.yaml --template-path tf.json --region us-east-1
 ```
 
 ***report***
@@ -59,15 +62,52 @@ $ pipenv run python iam_check/iam_check.py --config iam_check/config/default.yam
                             }
                         ],
                         "span": {
-                            "end": {
-                                "column": 34,
-                                "line": 6,
-                                "offset": 140
-                            },
                             "start": {
+                                "line": 9,
                                 "column": 18,
-                                "line": 6,
-                                "offset": 124
+                                "offset": 181
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 34,
+                                "offset": 197
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "findingType": "ERROR",
+            "code": "UNSUPPORTED_RESOURCE_ARN_IN_POLICY",
+            "message": "The resource ARN is not supported for the resource-based policy attached to resource type S3 Bucket.",
+            "resourceName": "demo-bucket",
+            "policyName": "aws_s3_bucket_policy.demo_bucket_policy",
+            "details": {
+                "findingDetails": "The resource ARN is not supported for the resource-based policy attached to resource type S3 Bucket.",
+                "findingType": "ERROR",
+                "issueCode": "UNSUPPORTED_RESOURCE_ARN_IN_POLICY",
+                "learnMoreLink": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-reference-policy-checks.html#access-analyzer-reference-policy-checks-error-unsupported-resource-arn-in-policy",
+                "locations": [
+                    {
+                        "path": [
+                            {
+                                "value": "Statement"
+                            },
+                            {
+                                "value": "Resource"
+                            }
+                        ],
+                        "span": {
+                            "start": {
+                                "line": 10,
+                                "column": 20,
+                                "offset": 219
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 23,
+                                "offset": 222
                             }
                         }
                     }


### PR DESCRIPTION
*Description of changes:*

  Hi. I appreciate the great tool you've provided!
  
  I tested the `example_report_3.md` file which checks with Amazon S3 bucket policy, and identified two issues:
  
  1. When running the `tf-policy-validator` command, it resulted in an `InvalidInput` error. The reason for this is that when checking Amazon S3 bucket policy, it is necessary to specify `policyType` as `RESOURCE_POLICY`. This condition is evaluated based on the presence of `Principal` in the policy. The relevant code can be found [here](https://github.com/awslabs/terraform-iam-policy-validator/blob/main/iam_check/lib/iamcheck_AccessAnalyzer.py#L43-L45). Therefore, I added `Principal` to the `aws_iam_policy_document` sample in `main.tf`.
  
  > botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the ValidatePolicy operation: InvalidInput
  
  2. After resolving the first issue, I found that IAM Access Analyzer detects not only `INVALID_ACTION` warnings but also `UNSUPPORTED_RESOURCE_ARN_IN_POLICY`. I have updated the execution results.
  
  Could you please review?
  
  Thank you.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
