### PR TITLE
Fix detection in modules

### DIFF
--- a/iam_check/lib/tfPlan.py
+++ b/iam_check/lib/tfPlan.py
@@ -342,7 +342,7 @@ class TerraformModule:
                 for child in value:
                     self.child_modules.append(TerraformModule(**child))
             else:
-                raise ValueError(f'Unkown parameter: {arg}')
+                raise ValueError(f'Unknown parameter: {arg}')
             
     def __eq__(self, o: object) -> bool:
         if self.address != o.address:
@@ -393,8 +393,8 @@ class TerraformModule:
         for m in self.child_modules:
             if m.address == key:
                 return key
-            if key.startswith(f'{r.address}.'):
-                return r.getValue(key)
+            if key.startswith(f'{m.address}.'):
+                return m.getValue(key)
         raise KeyError(f'Invalid terraform address: {key}')
 
     def listResources(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When running the `tf-policy-validator` on a project with modules it will not detect within modules. Applying this fix will parse through the nested modules as intended.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
