### PR TITLE
Updating Boto3 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ tf-policy-validator = "iam_check.iam_check:main"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-boto3 = "^1.26.77"
+boto3 = "^1.34.110"
 pyyaml = "^6.0"
 
 


### PR DESCRIPTION
Boto3 dependency was too low to discover Custom checks in the AWS SDK, so if the user had a sufficient version but the version did not contain an updated AWS SDK, it would error.

Updated Boto3 dependency to latest version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.