### PR TITLE
feat: IAM Validation for Service Control Policies

### DIFF
--- a/iam_check/lib/iamcheck_AccessAnalyzer.py
+++ b/iam_check/lib/iamcheck_AccessAnalyzer.py
@@ -69,26 +69,33 @@ class Validator:
             resource_name = plan.getResourceName(policy_name)
             p = iamPolicy.Policy(json=policy)
             LOGGER.info(f"start checking policy:{p}")
+
+            # Default to identity policy
             policyType = "IDENTITY_POLICY"
+            # Check for resource policy
             for statement in p.getStatement():
                 if (
-                    statement.getPrincipal() != None
-                    or statement.getNotPrincipal() != None
+                    statement.getPrincipal() is not None
+                    or statement.getNotPrincipal() is not None
                 ):
                     policyType = "RESOURCE_POLICY"
-                    continue
+                    break
+            # Check for Service Control Policy
+            if policy_resource_type == "aws_organizations_policy":
+                policyType = "SERVICE_CONTROL_POLICY"
+
             if policy_resource_type not in config.validatePolicyResourceType:
                 response = self.client.validate_policy(
                     policyDocument=str(p), policyType=policyType
                 )
             else:
-                policy_resource_type = config.validatePolicyResourceType[
+                policy_resource_type_mapped = config.validatePolicyResourceType[
                     policy_resource_type
                 ]
                 response = self.client.validate_policy(
                     policyDocument=str(p),
                     policyType=policyType,
-                    validatePolicyResourceType=policy_resource_type,
+                    validatePolicyResourceType=policy_resource_type_mapped,
                 )
             validation_findings = response["findings"]
             self.findings.add_validation_finding(
@@ -99,18 +106,22 @@ class Validator:
 def get_policy_type(resource_type, resource_attribute_name=None):
     # https://registry.terraform.io/providers/hashicorp/aws/latest/docs
     if resource_type in [
-        "aws_iam_group_policy",
-        "aws_iam_policy",
-        "aws_iam_role",
-        "aws_iam_role_policy",
-        "aws_iam_user_policy",
-    ]:
-        if (
-            resource_type == "aws_iam_role"
-            and resource_attribute_name == "assume_role_policy"
-        ):
-            return "RESOURCE_POLICY"
-        return "IDENTITY_POLICY"
+            "aws_iam_group_policy",
+            "aws_iam_policy",
+            "aws_iam_role",
+            "aws_iam_role_policy",
+            "aws_iam_user_policy",
+            "aws_organizations_policy",
+        ]:
+            if (
+                resource_type == "aws_iam_role"
+                and resource_attribute_name == "assume_role_policy"
+            ):
+                return "RESOURCE_POLICY"
+            # Detect Service Control Policy type
+            if resource_type == "aws_organizations_policy":
+                return "SERVICE_CONTROL_POLICY"
+            return "IDENTITY_POLICY"
     else:
         return "RESOURCE_POLICY"
 

--- a/iam_check/test/no_access_granted/actions_findings.json
+++ b/iam_check/test/no_access_granted/actions_findings.json
@@ -3,25 +3,23 @@
     {
       "findingType": "SECURITY_WARNING",
       "code": "policy-analysis-CheckAccessNotGranted",
-      "message": "The policy document grants access to perform one or more of the listed actions or resources.",
+      "message": "The policy document grants access to perform one or more of the listed actions.",
       "resourceName": "fakeBucket",
       "policyName": "aws_s3_bucket_policy.allow_access_from_another_account",
       "details": {
         "result": "FAIL",
         "reasons": [
           {
-            "description": "One or more of the listed actions or resources in the statement with index: 0.",
+            "description": "One or more of the listed actions in the statement with index: 0.",
             "statementIndex": 0,
             "accessInput": [
               {
-                "actions": [
-                  "s3:ListBucket"
-                ]
+                "actions": ["s3:ListBucket"]
               }
             ]
           }
         ],
-        "message": "The policy document grants access to perform one or more of the listed actions or resources."
+        "message": "The policy document grants access to perform one or more of the listed actions."
       }
     }
   ],

--- a/iam_check/test/no_access_granted/resources_and_actions_findings.json
+++ b/iam_check/test/no_access_granted/resources_and_actions_findings.json
@@ -3,14 +3,14 @@
     {
       "findingType": "SECURITY_WARNING",
       "code": "policy-analysis-CheckAccessNotGranted",
-      "message": "The policy document grants access to perform one or more of the listed actions or resources.",
+      "message": "The policy document grants access to one or more listed resources to perform one or more listed actions.",
       "resourceName": "fakeBucket",
       "policyName": "aws_s3_bucket_policy.allow_access_from_another_account",
       "details": {
         "result": "FAIL",
         "reasons": [
           {
-            "description": "One or more of the listed actions or resources in the statement with index: 0.",
+            "description": "One or more of the listed actions and/or resources in the statement with index: 0.",
             "statementIndex": 0,
             "accessInput": [
               {
@@ -24,7 +24,7 @@
             ]
           }
         ],
-        "message": "The policy document grants access to perform one or more of the listed actions or resources."
+        "message": "The policy document grants access to one or more listed resources to perform one or more listed actions."
       }
     }
   ],

--- a/iam_check/test/no_access_granted/resources_findings.json
+++ b/iam_check/test/no_access_granted/resources_findings.json
@@ -3,14 +3,14 @@
     {
       "findingType": "SECURITY_WARNING",
       "code": "policy-analysis-CheckAccessNotGranted",
-      "message": "The policy document grants access to perform one or more of the listed actions or resources.",
+      "message": "The policy document grants access to one or more of the listed resources.",
       "resourceName": "fakeBucket",
       "policyName": "aws_s3_bucket_policy.allow_access_from_another_account",
       "details": {
         "result": "FAIL",
         "reasons": [
           {
-            "description": "One or more of the listed actions or resources in the statement with index: 0.",
+            "description": "One or more of the listed resources in the statement with index: 0.",
             "statementIndex": 0,
             "accessInput": [
               {
@@ -21,7 +21,7 @@
             ]
           }
         ],
-        "message": "The policy document grants access to perform one or more of the listed actions or resources."
+        "message": "The policy document grants access to one or more of the listed resources."
       }
     }
   ],

--- a/iam_check/test/no_access_granted/test_plan.json
+++ b/iam_check/test/no_access_granted/test_plan.json
@@ -1,1 +1,732 @@
-{"format_version":"1.2","terraform_version":"1.8.3","planned_values":{"root_module":{"resources":[{"address":"aws_iam_access_key.lb","mode":"managed","type":"aws_iam_access_key","name":"lb","provider_name":"registry.terraform.io/hashicorp/aws","schema_version":0,"values":{"pgp_key":null,"status":"Active","user":"loadbalancer"},"sensitive_values":{"secret":true,"ses_smtp_password_v4":true}},{"address":"aws_iam_user.lb","mode":"managed","type":"aws_iam_user","name":"lb","provider_name":"registry.terraform.io/hashicorp/aws","schema_version":0,"values":{"force_destroy":false,"name":"loadbalancer","path":"/system/","permissions_boundary":null,"tags":{"tag-key":"tag-value"},"tags_all":{"tag-key":"tag-value"}},"sensitive_values":{"tags":{},"tags_all":{}}},{"address":"aws_s3_bucket.example","mode":"managed","type":"aws_s3_bucket","name":"example","provider_name":"registry.terraform.io/hashicorp/aws","schema_version":0,"values":{"bucket":"my-tf-test-bucket","force_destroy":false,"tags":null,"timeouts":null},"sensitive_values":{"cors_rule":[],"grant":[],"lifecycle_rule":[],"logging":[],"object_lock_configuration":[],"replication_configuration":[],"server_side_encryption_configuration":[],"tags_all":{},"versioning":[],"website":[]}},{"address":"aws_s3_bucket.other","mode":"managed","type":"aws_s3_bucket","name":"other","provider_name":"registry.terraform.io/hashicorp/aws","schema_version":0,"values":{"bucket":"other-tf-test-bucket","force_destroy":false,"tags":null,"timeouts":null},"sensitive_values":{"cors_rule":[],"grant":[],"lifecycle_rule":[],"logging":[],"object_lock_configuration":[],"replication_configuration":[],"server_side_encryption_configuration":[],"tags_all":{},"versioning":[],"website":[]}},{"address":"aws_s3_bucket_policy.allow_access_from_another_account","mode":"managed","type":"aws_s3_bucket_policy","name":"allow_access_from_another_account","provider_name":"registry.terraform.io/hashicorp/aws","schema_version":0,"values":{"policy":"{\"Statement\":[{\"Action\":[\"s3:ListBucket\",\"s3:GetObject\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"123456789012\"},\"Resource\":\"arn:aws:s3:::example\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}"},"sensitive_values":{}},{"address":"aws_s3_bucket_policy.allow_access_from_other_account","mode":"managed","type":"aws_s3_bucket_policy","name":"allow_access_from_other_account","provider_name":"registry.terraform.io/hashicorp/aws","schema_version":0,"values":{"policy":"{\"Statement\":[{\"Action\":[\"s3:PutObject\",\"s3:GetObject\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"123456789012\"},\"Resource\":\"arn:aws:s3:::other\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}"},"sensitive_values":{}}]}},"resource_changes":[{"address":"aws_iam_access_key.lb","mode":"managed","type":"aws_iam_access_key","name":"lb","provider_name":"registry.terraform.io/hashicorp/aws","change":{"actions":["create"],"before":null,"after":{"pgp_key":null,"status":"Active","user":"loadbalancer"},"after_unknown":{"create_date":true,"encrypted_secret":true,"encrypted_ses_smtp_password_v4":true,"id":true,"key_fingerprint":true,"secret":true,"ses_smtp_password_v4":true},"before_sensitive":false,"after_sensitive":{"secret":true,"ses_smtp_password_v4":true}}},{"address":"aws_iam_user.lb","mode":"managed","type":"aws_iam_user","name":"lb","provider_name":"registry.terraform.io/hashicorp/aws","change":{"actions":["create"],"before":null,"after":{"force_destroy":false,"name":"loadbalancer","path":"/system/","permissions_boundary":null,"tags":{"tag-key":"tag-value"},"tags_all":{"tag-key":"tag-value"}},"after_unknown":{"arn":true,"id":true,"tags":{},"tags_all":{},"unique_id":true},"before_sensitive":false,"after_sensitive":{"tags":{},"tags_all":{}}}},{"address":"aws_s3_bucket.example","mode":"managed","type":"aws_s3_bucket","name":"example","provider_name":"registry.terraform.io/hashicorp/aws","change":{"actions":["create"],"before":null,"after":{"bucket":"my-tf-test-bucket","force_destroy":false,"tags":null,"timeouts":null},"after_unknown":{"acceleration_status":true,"acl":true,"arn":true,"bucket_domain_name":true,"bucket_prefix":true,"bucket_regional_domain_name":true,"cors_rule":true,"grant":true,"hosted_zone_id":true,"id":true,"lifecycle_rule":true,"logging":true,"object_lock_configuration":true,"object_lock_enabled":true,"policy":true,"region":true,"replication_configuration":true,"request_payer":true,"server_side_encryption_configuration":true,"tags_all":true,"versioning":true,"website":true,"website_domain":true,"website_endpoint":true},"before_sensitive":false,"after_sensitive":{"cors_rule":[],"grant":[],"lifecycle_rule":[],"logging":[],"object_lock_configuration":[],"replication_configuration":[],"server_side_encryption_configuration":[],"tags_all":{},"versioning":[],"website":[]}}},{"address":"aws_s3_bucket.other","mode":"managed","type":"aws_s3_bucket","name":"other","provider_name":"registry.terraform.io/hashicorp/aws","change":{"actions":["create"],"before":null,"after":{"bucket":"other-tf-test-bucket","force_destroy":false,"tags":null,"timeouts":null},"after_unknown":{"acceleration_status":true,"acl":true,"arn":true,"bucket_domain_name":true,"bucket_prefix":true,"bucket_regional_domain_name":true,"cors_rule":true,"grant":true,"hosted_zone_id":true,"id":true,"lifecycle_rule":true,"logging":true,"object_lock_configuration":true,"object_lock_enabled":true,"policy":true,"region":true,"replication_configuration":true,"request_payer":true,"server_side_encryption_configuration":true,"tags_all":true,"versioning":true,"website":true,"website_domain":true,"website_endpoint":true},"before_sensitive":false,"after_sensitive":{"cors_rule":[],"grant":[],"lifecycle_rule":[],"logging":[],"object_lock_configuration":[],"replication_configuration":[],"server_side_encryption_configuration":[],"tags_all":{},"versioning":[],"website":[]}}},{"address":"aws_s3_bucket_policy.allow_access_from_another_account","mode":"managed","type":"aws_s3_bucket_policy","name":"allow_access_from_another_account","provider_name":"registry.terraform.io/hashicorp/aws","change":{"actions":["create"],"before":null,"after":{"policy":"{\"Statement\":[{\"Action\":[\"s3:ListBucket\",\"s3:GetObject\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"123456789012\"},\"Resource\":\"arn:aws:s3:::example\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}"},"after_unknown":{"bucket":true,"id":true},"before_sensitive":false,"after_sensitive":{}}},{"address":"aws_s3_bucket_policy.allow_access_from_other_account","mode":"managed","type":"aws_s3_bucket_policy","name":"allow_access_from_other_account","provider_name":"registry.terraform.io/hashicorp/aws","change":{"actions":["create"],"before":null,"after":{"policy":"{\"Statement\":[{\"Action\":[\"s3:PutObject\",\"s3:GetObject\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"123456789012\"},\"Resource\":\"arn:aws:s3:::other\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}"},"after_unknown":{"bucket":true,"id":true},"before_sensitive":false,"after_sensitive":{}}}],"prior_state":{"format_version":"1.0","terraform_version":"1.8.3","values":{"root_module":{"resources":[{"address":"data.aws_iam_policy_document.allow_access_from_another_account","mode":"data","type":"aws_iam_policy_document","name":"allow_access_from_another_account","provider_name":"registry.terraform.io/hashicorp/aws","schema_version":0,"values":{"id":"3101413077","json":"{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"s3:ListBucket\",\n        \"s3:GetObject\"\n      ],\n      \"Resource\": \"arn:aws:s3:::example\",\n      \"Principal\": {\n        \"AWS\": \"123456789012\"\n      }\n    }\n  ]\n}","override_json":null,"override_policy_documents":null,"policy_id":null,"source_json":null,"source_policy_documents":null,"statement":[{"actions":["s3:GetObject","s3:ListBucket"],"condition":[],"effect":"Allow","not_actions":[],"not_principals":[],"not_resources":[],"principals":[{"identifiers":["123456789012"],"type":"AWS"}],"resources":["arn:aws:s3:::example"],"sid":""}],"version":"2012-10-17"},"sensitive_values":{"statement":[{"actions":[false,false],"condition":[],"not_actions":[],"not_principals":[],"not_resources":[],"principals":[{"identifiers":[false]}],"resources":[false]}]}},{"address":"data.aws_iam_policy_document.allow_put_access_from_other_account","mode":"data","type":"aws_iam_policy_document","name":"allow_put_access_from_other_account","provider_name":"registry.terraform.io/hashicorp/aws","schema_version":0,"values":{"id":"172802538","json":"{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"s3:PutObject\",\n        \"s3:GetObject\"\n      ],\n      \"Resource\": \"arn:aws:s3:::other\",\n      \"Principal\": {\n        \"AWS\": \"123456789012\"\n      }\n    }\n  ]\n}","override_json":null,"override_policy_documents":null,"policy_id":null,"source_json":null,"source_policy_documents":null,"statement":[{"actions":["s3:GetObject","s3:PutObject"],"condition":[],"effect":"Allow","not_actions":[],"not_principals":[],"not_resources":[],"principals":[{"identifiers":["123456789012"],"type":"AWS"}],"resources":["arn:aws:s3:::other"],"sid":""}],"version":"2012-10-17"},"sensitive_values":{"statement":[{"actions":[false,false],"condition":[],"not_actions":[],"not_principals":[],"not_resources":[],"principals":[{"identifiers":[false]}],"resources":[false]}]}}]}}},"configuration":{"provider_config":{"aws":{"name":"aws","full_name":"registry.terraform.io/hashicorp/aws","version_constraint":"~\u003e 4.0"}},"root_module":{"resources":[{"address":"aws_iam_access_key.lb","mode":"managed","type":"aws_iam_access_key","name":"lb","provider_config_key":"aws","expressions":{"user":{"references":["aws_iam_user.lb.name","aws_iam_user.lb"]}},"schema_version":0},{"address":"aws_iam_user.lb","mode":"managed","type":"aws_iam_user","name":"lb","provider_config_key":"aws","expressions":{"name":{"constant_value":"loadbalancer"},"path":{"constant_value":"/system/"},"tags":{"constant_value":{"tag-key":"tag-value"}}},"schema_version":0},{"address":"aws_s3_bucket.example","mode":"managed","type":"aws_s3_bucket","name":"example","provider_config_key":"aws","expressions":{"bucket":{"constant_value":"my-tf-test-bucket"}},"schema_version":0},{"address":"aws_s3_bucket.other","mode":"managed","type":"aws_s3_bucket","name":"other","provider_config_key":"aws","expressions":{"bucket":{"constant_value":"other-tf-test-bucket"}},"schema_version":0},{"address":"aws_s3_bucket_policy.allow_access_from_another_account","mode":"managed","type":"aws_s3_bucket_policy","name":"allow_access_from_another_account","provider_config_key":"aws","expressions":{"bucket":{"references":["aws_s3_bucket.example.id","aws_s3_bucket.example"]},"policy":{"references":["data.aws_iam_policy_document.allow_access_from_another_account.json","data.aws_iam_policy_document.allow_access_from_another_account"]}},"schema_version":0},{"address":"aws_s3_bucket_policy.allow_access_from_other_account","mode":"managed","type":"aws_s3_bucket_policy","name":"allow_access_from_other_account","provider_config_key":"aws","expressions":{"bucket":{"references":["aws_s3_bucket.other.id","aws_s3_bucket.other"]},"policy":{"references":["data.aws_iam_policy_document.allow_put_access_from_other_account.json","data.aws_iam_policy_document.allow_put_access_from_other_account"]}},"schema_version":0},{"address":"data.aws_iam_policy_document.allow_access_from_another_account","mode":"data","type":"aws_iam_policy_document","name":"allow_access_from_another_account","provider_config_key":"aws","expressions":{"statement":[{"actions":{"constant_value":["s3:GetObject","s3:ListBucket"]},"principals":[{"identifiers":{"constant_value":["123456789012"]},"type":{"constant_value":"AWS"}}],"resources":{"constant_value":["arn:aws:s3:::example"]}}]},"schema_version":0},{"address":"data.aws_iam_policy_document.allow_put_access_from_other_account","mode":"data","type":"aws_iam_policy_document","name":"allow_put_access_from_other_account","provider_config_key":"aws","expressions":{"statement":[{"actions":{"constant_value":["s3:GetObject","s3:PutObject"]},"principals":[{"identifiers":{"constant_value":["123456789012"]},"type":{"constant_value":"AWS"}}],"resources":{"constant_value":["arn:aws:s3:::other"]}}]},"schema_version":0}]}},"relevant_attributes":[{"resource":"aws_iam_user.lb","attribute":["name"]},{"resource":"data.aws_iam_policy_document.allow_access_from_another_account","attribute":["json"]},{"resource":"aws_s3_bucket.example","attribute":["id"]},{"resource":"data.aws_iam_policy_document.allow_put_access_from_other_account","attribute":["json"]},{"resource":"aws_s3_bucket.other","attribute":["id"]}],"timestamp":"2024-05-28T13:50:39Z","applyable":true,"complete":true,"errored":false}
+{
+    "format_version": "1.2",
+    "terraform_version": "1.8.3",
+    "planned_values": {
+        "root_module": {
+            "resources": [
+                {
+                    "address": "aws_iam_access_key.lb",
+                    "mode": "managed",
+                    "type": "aws_iam_access_key",
+                    "name": "lb",
+                    "provider_name": "registry.terraform.io/hashicorp/aws",
+                    "schema_version": 0,
+                    "values": {
+                        "pgp_key": null,
+                        "status": "Active",
+                        "user": "loadbalancer"
+                    },
+                    "sensitive_values": {
+                        "secret": true,
+                        "ses_smtp_password_v4": true
+                    }
+                },
+                {
+                    "address": "aws_iam_user.lb",
+                    "mode": "managed",
+                    "type": "aws_iam_user",
+                    "name": "lb",
+                    "provider_name": "registry.terraform.io/hashicorp/aws",
+                    "schema_version": 0,
+                    "values": {
+                        "force_destroy": false,
+                        "name": "loadbalancer",
+                        "path": "/system/",
+                        "permissions_boundary": null,
+                        "tags": {
+                            "tag-key": "tag-value"
+                        },
+                        "tags_all": {
+                            "tag-key": "tag-value"
+                        }
+                    },
+                    "sensitive_values": {
+                        "tags": {},
+                        "tags_all": {}
+                    }
+                },
+                {
+                    "address": "aws_s3_bucket.example",
+                    "mode": "managed",
+                    "type": "aws_s3_bucket",
+                    "name": "example",
+                    "provider_name": "registry.terraform.io/hashicorp/aws",
+                    "schema_version": 0,
+                    "values": {
+                        "bucket": "my-tf-test-bucket",
+                        "force_destroy": false,
+                        "tags": null,
+                        "timeouts": null
+                    },
+                    "sensitive_values": {
+                        "cors_rule": [],
+                        "grant": [],
+                        "lifecycle_rule": [],
+                        "logging": [],
+                        "object_lock_configuration": [],
+                        "replication_configuration": [],
+                        "server_side_encryption_configuration": [],
+                        "tags_all": {},
+                        "versioning": [],
+                        "website": []
+                    }
+                },
+                {
+                    "address": "aws_s3_bucket.other",
+                    "mode": "managed",
+                    "type": "aws_s3_bucket",
+                    "name": "other",
+                    "provider_name": "registry.terraform.io/hashicorp/aws",
+                    "schema_version": 0,
+                    "values": {
+                        "bucket": "other-tf-test-bucket",
+                        "force_destroy": false,
+                        "tags": null,
+                        "timeouts": null
+                    },
+                    "sensitive_values": {
+                        "cors_rule": [],
+                        "grant": [],
+                        "lifecycle_rule": [],
+                        "logging": [],
+                        "object_lock_configuration": [],
+                        "replication_configuration": [],
+                        "server_side_encryption_configuration": [],
+                        "tags_all": {},
+                        "versioning": [],
+                        "website": []
+                    }
+                },
+                {
+                    "address": "aws_s3_bucket_policy.allow_access_from_another_account",
+                    "mode": "managed",
+                    "type": "aws_s3_bucket_policy",
+                    "name": "allow_access_from_another_account",
+                    "provider_name": "registry.terraform.io/hashicorp/aws",
+                    "schema_version": 0,
+                    "values": {
+                        "policy": "{\"Statement\":[{\"Action\":[\"s3:ListBucket\",\"s3:GetObject\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"123456789012\"},\"Resource\":\"arn:aws:s3:::example\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}"
+                    },
+                    "sensitive_values": {}
+                },
+                {
+                    "address": "aws_s3_bucket_policy.allow_access_from_other_account",
+                    "mode": "managed",
+                    "type": "aws_s3_bucket_policy",
+                    "name": "allow_access_from_other_account",
+                    "provider_name": "registry.terraform.io/hashicorp/aws",
+                    "schema_version": 0,
+                    "values": {
+                        "policy": "{\"Statement\":[{\"Action\":[\"s3:PutObject\",\"s3:GetObject\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"123456789012\"},\"Resource\":\"arn:aws:s3:::other\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}"
+                    },
+                    "sensitive_values": {}
+                }
+            ]
+        }
+    },
+    "resource_changes": [
+        {
+            "address": "aws_iam_access_key.lb",
+            "mode": "managed",
+            "type": "aws_iam_access_key",
+            "name": "lb",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "pgp_key": null,
+                    "status": "Active",
+                    "user": "loadbalancer"
+                },
+                "after_unknown": {
+                    "create_date": true,
+                    "encrypted_secret": true,
+                    "encrypted_ses_smtp_password_v4": true,
+                    "id": true,
+                    "key_fingerprint": true,
+                    "secret": true,
+                    "ses_smtp_password_v4": true
+                },
+                "before_sensitive": false,
+                "after_sensitive": {
+                    "secret": true,
+                    "ses_smtp_password_v4": true
+                }
+            }
+        },
+        {
+            "address": "aws_iam_user.lb",
+            "mode": "managed",
+            "type": "aws_iam_user",
+            "name": "lb",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "force_destroy": false,
+                    "name": "loadbalancer",
+                    "path": "/system/",
+                    "permissions_boundary": null,
+                    "tags": {
+                        "tag-key": "tag-value"
+                    },
+                    "tags_all": {
+                        "tag-key": "tag-value"
+                    }
+                },
+                "after_unknown": {
+                    "arn": true,
+                    "id": true,
+                    "tags": {},
+                    "tags_all": {},
+                    "unique_id": true
+                },
+                "before_sensitive": false,
+                "after_sensitive": {
+                    "tags": {},
+                    "tags_all": {}
+                }
+            }
+        },
+        {
+            "address": "aws_s3_bucket.example",
+            "mode": "managed",
+            "type": "aws_s3_bucket",
+            "name": "example",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "bucket": "my-tf-test-bucket",
+                    "force_destroy": false,
+                    "tags": null,
+                    "timeouts": null
+                },
+                "after_unknown": {
+                    "acceleration_status": true,
+                    "acl": true,
+                    "arn": true,
+                    "bucket_domain_name": true,
+                    "bucket_prefix": true,
+                    "bucket_regional_domain_name": true,
+                    "cors_rule": true,
+                    "grant": true,
+                    "hosted_zone_id": true,
+                    "id": true,
+                    "lifecycle_rule": true,
+                    "logging": true,
+                    "object_lock_configuration": true,
+                    "object_lock_enabled": true,
+                    "policy": true,
+                    "region": true,
+                    "replication_configuration": true,
+                    "request_payer": true,
+                    "server_side_encryption_configuration": true,
+                    "tags_all": true,
+                    "versioning": true,
+                    "website": true,
+                    "website_domain": true,
+                    "website_endpoint": true
+                },
+                "before_sensitive": false,
+                "after_sensitive": {
+                    "cors_rule": [],
+                    "grant": [],
+                    "lifecycle_rule": [],
+                    "logging": [],
+                    "object_lock_configuration": [],
+                    "replication_configuration": [],
+                    "server_side_encryption_configuration": [],
+                    "tags_all": {},
+                    "versioning": [],
+                    "website": []
+                }
+            }
+        },
+        {
+            "address": "aws_s3_bucket.other",
+            "mode": "managed",
+            "type": "aws_s3_bucket",
+            "name": "other",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "bucket": "other-tf-test-bucket",
+                    "force_destroy": false,
+                    "tags": null,
+                    "timeouts": null
+                },
+                "after_unknown": {
+                    "acceleration_status": true,
+                    "acl": true,
+                    "arn": true,
+                    "bucket_domain_name": true,
+                    "bucket_prefix": true,
+                    "bucket_regional_domain_name": true,
+                    "cors_rule": true,
+                    "grant": true,
+                    "hosted_zone_id": true,
+                    "id": true,
+                    "lifecycle_rule": true,
+                    "logging": true,
+                    "object_lock_configuration": true,
+                    "object_lock_enabled": true,
+                    "policy": true,
+                    "region": true,
+                    "replication_configuration": true,
+                    "request_payer": true,
+                    "server_side_encryption_configuration": true,
+                    "tags_all": true,
+                    "versioning": true,
+                    "website": true,
+                    "website_domain": true,
+                    "website_endpoint": true
+                },
+                "before_sensitive": false,
+                "after_sensitive": {
+                    "cors_rule": [],
+                    "grant": [],
+                    "lifecycle_rule": [],
+                    "logging": [],
+                    "object_lock_configuration": [],
+                    "replication_configuration": [],
+                    "server_side_encryption_configuration": [],
+                    "tags_all": {},
+                    "versioning": [],
+                    "website": []
+                }
+            }
+        },
+        {
+            "address": "aws_s3_bucket_policy.allow_access_from_another_account",
+            "mode": "managed",
+            "type": "aws_s3_bucket_policy",
+            "name": "allow_access_from_another_account",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "policy": "{\"Statement\":[{\"Action\":[\"s3:ListBucket\",\"s3:GetObject\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"123456789012\"},\"Resource\":\"arn:aws:s3:::example\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}"
+                },
+                "after_unknown": {
+                    "bucket": true,
+                    "id": true
+                },
+                "before_sensitive": false,
+                "after_sensitive": {}
+            }
+        },
+        {
+            "address": "aws_s3_bucket_policy.allow_access_from_other_account",
+            "mode": "managed",
+            "type": "aws_s3_bucket_policy",
+            "name": "allow_access_from_other_account",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "policy": "{\"Statement\":[{\"Action\":[\"s3:PutObject\",\"s3:GetObject\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"123456789012\"},\"Resource\":\"arn:aws:s3:::other\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}"
+                },
+                "after_unknown": {
+                    "bucket": true,
+                    "id": true
+                },
+                "before_sensitive": false,
+                "after_sensitive": {}
+            }
+        }
+    ],
+    "prior_state": {
+        "format_version": "1.0",
+        "terraform_version": "1.8.3",
+        "values": {
+            "root_module": {
+                "resources": [
+                    {
+                        "address": "data.aws_iam_policy_document.allow_access_from_another_account",
+                        "mode": "data",
+                        "type": "aws_iam_policy_document",
+                        "name": "allow_access_from_another_account",
+                        "provider_name": "registry.terraform.io/hashicorp/aws",
+                        "schema_version": 0,
+                        "values": {
+                            "id": "3101413077",
+                            "json": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"s3:ListBucket\",\n        \"s3:GetObject\"\n      ],\n      \"Resource\": \"arn:aws:s3:::example\",\n      \"Principal\": {\n        \"AWS\": \"123456789012\"\n      }\n    }\n  ]\n}",
+                            "override_json": null,
+                            "override_policy_documents": null,
+                            "policy_id": null,
+                            "source_json": null,
+                            "source_policy_documents": null,
+                            "statement": [
+                                {
+                                    "actions": [
+                                        "s3:GetObject",
+                                        "s3:ListBucket"
+                                    ],
+                                    "condition": [],
+                                    "effect": "Allow",
+                                    "not_actions": [],
+                                    "not_principals": [],
+                                    "not_resources": [],
+                                    "principals": [
+                                        {
+                                            "identifiers": [
+                                                "123456789012"
+                                            ],
+                                            "type": "AWS"
+                                        }
+                                    ],
+                                    "resources": [
+                                        "arn:aws:s3:::example"
+                                    ],
+                                    "sid": ""
+                                }
+                            ],
+                            "version": "2012-10-17"
+                        },
+                        "sensitive_values": {
+                            "statement": [
+                                {
+                                    "actions": [
+                                        false,
+                                        false
+                                    ],
+                                    "condition": [],
+                                    "not_actions": [],
+                                    "not_principals": [],
+                                    "not_resources": [],
+                                    "principals": [
+                                        {
+                                            "identifiers": [
+                                                false
+                                            ]
+                                        }
+                                    ],
+                                    "resources": [
+                                        false
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "address": "data.aws_iam_policy_document.allow_put_access_from_other_account",
+                        "mode": "data",
+                        "type": "aws_iam_policy_document",
+                        "name": "allow_put_access_from_other_account",
+                        "provider_name": "registry.terraform.io/hashicorp/aws",
+                        "schema_version": 0,
+                        "values": {
+                            "id": "172802538",
+                            "json": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"s3:PutObject\",\n        \"s3:GetObject\"\n      ],\n      \"Resource\": \"arn:aws:s3:::other\",\n      \"Principal\": {\n        \"AWS\": \"123456789012\"\n      }\n    }\n  ]\n}",
+                            "override_json": null,
+                            "override_policy_documents": null,
+                            "policy_id": null,
+                            "source_json": null,
+                            "source_policy_documents": null,
+                            "statement": [
+                                {
+                                    "actions": [
+                                        "s3:GetObject",
+                                        "s3:PutObject"
+                                    ],
+                                    "condition": [],
+                                    "effect": "Allow",
+                                    "not_actions": [],
+                                    "not_principals": [],
+                                    "not_resources": [],
+                                    "principals": [
+                                        {
+                                            "identifiers": [
+                                                "123456789012"
+                                            ],
+                                            "type": "AWS"
+                                        }
+                                    ],
+                                    "resources": [
+                                        "arn:aws:s3:::other"
+                                    ],
+                                    "sid": ""
+                                }
+                            ],
+                            "version": "2012-10-17"
+                        },
+                        "sensitive_values": {
+                            "statement": [
+                                {
+                                    "actions": [
+                                        false,
+                                        false
+                                    ],
+                                    "condition": [],
+                                    "not_actions": [],
+                                    "not_principals": [],
+                                    "not_resources": [],
+                                    "principals": [
+                                        {
+                                            "identifiers": [
+                                                false
+                                            ]
+                                        }
+                                    ],
+                                    "resources": [
+                                        false
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "configuration": {
+        "provider_config": {
+            "aws": {
+                "name": "aws",
+                "full_name": "registry.terraform.io/hashicorp/aws",
+                "version_constraint": "~\u003e 4.0"
+            }
+        },
+        "root_module": {
+            "resources": [
+                {
+                    "address": "aws_iam_access_key.lb",
+                    "mode": "managed",
+                    "type": "aws_iam_access_key",
+                    "name": "lb",
+                    "provider_config_key": "aws",
+                    "expressions": {
+                        "user": {
+                            "references": [
+                                "aws_iam_user.lb.name",
+                                "aws_iam_user.lb"
+                            ]
+                        }
+                    },
+                    "schema_version": 0
+                },
+                {
+                    "address": "aws_iam_user.lb",
+                    "mode": "managed",
+                    "type": "aws_iam_user",
+                    "name": "lb",
+                    "provider_config_key": "aws",
+                    "expressions": {
+                        "name": {
+                            "constant_value": "loadbalancer"
+                        },
+                        "path": {
+                            "constant_value": "/system/"
+                        },
+                        "tags": {
+                            "constant_value": {
+                                "tag-key": "tag-value"
+                            }
+                        }
+                    },
+                    "schema_version": 0
+                },
+                {
+                    "address": "aws_s3_bucket.example",
+                    "mode": "managed",
+                    "type": "aws_s3_bucket",
+                    "name": "example",
+                    "provider_config_key": "aws",
+                    "expressions": {
+                        "bucket": {
+                            "constant_value": "my-tf-test-bucket"
+                        }
+                    },
+                    "schema_version": 0
+                },
+                {
+                    "address": "aws_s3_bucket.other",
+                    "mode": "managed",
+                    "type": "aws_s3_bucket",
+                    "name": "other",
+                    "provider_config_key": "aws",
+                    "expressions": {
+                        "bucket": {
+                            "constant_value": "other-tf-test-bucket"
+                        }
+                    },
+                    "schema_version": 0
+                },
+                {
+                    "address": "aws_s3_bucket_policy.allow_access_from_another_account",
+                    "mode": "managed",
+                    "type": "aws_s3_bucket_policy",
+                    "name": "allow_access_from_another_account",
+                    "provider_config_key": "aws",
+                    "expressions": {
+                        "bucket": {
+                            "references": [
+                                "aws_s3_bucket.example.id",
+                                "aws_s3_bucket.example"
+                            ]
+                        },
+                        "policy": {
+                            "references": [
+                                "data.aws_iam_policy_document.allow_access_from_another_account.json",
+                                "data.aws_iam_policy_document.allow_access_from_another_account"
+                            ]
+                        }
+                    },
+                    "schema_version": 0
+                },
+                {
+                    "address": "aws_s3_bucket_policy.allow_access_from_other_account",
+                    "mode": "managed",
+                    "type": "aws_s3_bucket_policy",
+                    "name": "allow_access_from_other_account",
+                    "provider_config_key": "aws",
+                    "expressions": {
+                        "bucket": {
+                            "references": [
+                                "aws_s3_bucket.other.id",
+                                "aws_s3_bucket.other"
+                            ]
+                        },
+                        "policy": {
+                            "references": [
+                                "data.aws_iam_policy_document.allow_put_access_from_other_account.json",
+                                "data.aws_iam_policy_document.allow_put_access_from_other_account"
+                            ]
+                        }
+                    },
+                    "schema_version": 0
+                },
+                {
+                    "address": "data.aws_iam_policy_document.allow_access_from_another_account",
+                    "mode": "data",
+                    "type": "aws_iam_policy_document",
+                    "name": "allow_access_from_another_account",
+                    "provider_config_key": "aws",
+                    "expressions": {
+                        "statement": [
+                            {
+                                "actions": {
+                                    "constant_value": [
+                                        "s3:GetObject",
+                                        "s3:ListBucket"
+                                    ]
+                                },
+                                "principals": [
+                                    {
+                                        "identifiers": {
+                                            "constant_value": [
+                                                "123456789012"
+                                            ]
+                                        },
+                                        "type": {
+                                            "constant_value": "AWS"
+                                        }
+                                    }
+                                ],
+                                "resources": {
+                                    "constant_value": [
+                                        "arn:aws:s3:::example"
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "schema_version": 0
+                },
+                {
+                    "address": "data.aws_iam_policy_document.allow_put_access_from_other_account",
+                    "mode": "data",
+                    "type": "aws_iam_policy_document",
+                    "name": "allow_put_access_from_other_account",
+                    "provider_config_key": "aws",
+                    "expressions": {
+                        "statement": [
+                            {
+                                "actions": {
+                                    "constant_value": [
+                                        "s3:GetObject",
+                                        "s3:PutObject"
+                                    ]
+                                },
+                                "principals": [
+                                    {
+                                        "identifiers": {
+                                            "constant_value": [
+                                                "123456789012"
+                                            ]
+                                        },
+                                        "type": {
+                                            "constant_value": "AWS"
+                                        }
+                                    }
+                                ],
+                                "resources": {
+                                    "constant_value": [
+                                        "arn:aws:s3:::other"
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "schema_version": 0
+                }
+            ]
+        }
+    },
+    "relevant_attributes": [
+        {
+            "resource": "aws_iam_user.lb",
+            "attribute": [
+                "name"
+            ]
+        },
+        {
+            "resource": "data.aws_iam_policy_document.allow_access_from_another_account",
+            "attribute": [
+                "json"
+            ]
+        },
+        {
+            "resource": "aws_s3_bucket.example",
+            "attribute": [
+                "id"
+            ]
+        },
+        {
+            "resource": "data.aws_iam_policy_document.allow_put_access_from_other_account",
+            "attribute": [
+                "json"
+            ]
+        },
+        {
+            "resource": "aws_s3_bucket.other",
+            "attribute": [
+                "id"
+            ]
+        }
+    ],
+    "timestamp": "2024-05-28T13:50:39Z",
+    "applyable": true,
+    "complete": true,
+    "errored": false
+}

--- a/iam_check/test/scp/findings.json
+++ b/iam_check/test/scp/findings.json
@@ -1,0 +1,43 @@
+{
+  "BlockingFindings": [
+    {
+      "findingType": "ERROR",
+      "code": "SCP_SYNTAX_ERROR_NOTRESOURCE",
+      "message": "SCPs do not support the NotResource element. Update the policy to use Resource instead.",
+      "resourceName": "demo-scp",
+      "policyName": "aws_organizations_policy.demo_scp",
+      "details": {
+        "findingDetails": "SCPs do not support the NotResource element. Update the policy to use Resource instead.",
+        "findingType": "ERROR",
+        "issueCode": "SCP_SYNTAX_ERROR_NOTRESOURCE",
+        "learnMoreLink": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-reference-policy-checks.html#access-analyzer-reference-policy-checks-error-scp-syntax-error-notresource",
+        "locations": [
+          {
+            "path": [
+              {
+                "value": "Statement"
+              },
+              {
+                "value": "NotResource"
+              }
+            ],
+            "span": {
+              "start": {
+                "line": 10,
+                "column": 23,
+                "offset": 242
+              },
+              "end": {
+                "line": 10,
+                "column": 26,
+                "offset": 245
+              }
+            }
+          }
+        ]
+      },
+      "message": "SCPs do not support the NotResource element. Update the policy to use Resource instead."
+  }
+],
+"NonBlockingFindings": []
+}

--- a/iam_check/test/scp/test.tf
+++ b/iam_check/test/scp/test.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+resource "aws_organizations_policy" "demo_scp" {
+  name        = "demo-scp"
+  description = "This is a demo Service Control Policy"
+  content     = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyAllExceptList",
+      "Effect": "Deny",
+      "NotAction": [
+        "organizations:List*",
+        "organizations:Describe*"
+      ],
+      "NotResource": "*"
+    }
+  ]
+}
+POLICY
+  type        = "SERVICE_CONTROL_POLICY"
+}

--- a/iam_check/test/scp/test_plan.json
+++ b/iam_check/test/scp/test_plan.json
@@ -1,0 +1,100 @@
+{
+    "format_version": "1.2",
+    "terraform_version": "1.11.2",
+    "planned_values": {
+        "root_module": {
+            "resources": [
+                {
+                    "address": "aws_organizations_policy.demo_scp",
+                    "mode": "managed",
+                    "type": "aws_organizations_policy",
+                    "name": "demo_scp",
+                    "provider_name": "registry.terraform.io/hashicorp/aws",
+                    "schema_version": 0,
+                    "values": {
+                        "content": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"DenyAllExceptList\",\n      \"Effect\": \"Deny\",\n      \"NotAction\": [\n        \"organizations:List*\",\n        \"organizations:Describe*\"\n      ],\n      \"NotResource\": \"*\"\n    }\n  ]\n}\n",
+                        "description": "This is a demo Service Control Policy",
+                        "name": "demo-scp",
+                        "skip_destroy": null,
+                        "tags": null,
+                        "type": "SERVICE_CONTROL_POLICY"
+                    },
+                    "sensitive_values": {
+                        "tags_all": {}
+                    }
+                }
+            ]
+        }
+    },
+    "resource_changes": [
+        {
+            "address": "aws_organizations_policy.demo_scp",
+            "mode": "managed",
+            "type": "aws_organizations_policy",
+            "name": "demo_scp",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "content": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"DenyAllExceptList\",\n      \"Effect\": \"Deny\",\n      \"NotAction\": [\n        \"organizations:List*\",\n        \"organizations:Describe*\"\n      ],\n      \"NotResource\": \"*\"\n    }\n  ]\n}\n",
+                    "description": "This is a demo Service Control Policy",
+                    "name": "demo-scp",
+                    "skip_destroy": null,
+                    "tags": null,
+                    "type": "SERVICE_CONTROL_POLICY"
+                },
+                "after_unknown": {
+                    "arn": true,
+                    "id": true,
+                    "tags_all": true
+                },
+                "before_sensitive": false,
+                "after_sensitive": {
+                    "tags_all": {}
+                }
+            }
+        }
+    ],
+    "configuration": {
+        "provider_config": {
+            "aws": {
+                "name": "aws",
+                "full_name": "registry.terraform.io/hashicorp/aws",
+                "version_constraint": "~\u003e 4.0"
+            }
+        },
+        "root_module": {
+            "resources": [
+                {
+                    "address": "aws_organizations_policy.demo_scp",
+                    "mode": "managed",
+                    "type": "aws_organizations_policy",
+                    "name": "demo_scp",
+                    "provider_config_key": "aws",
+                    "expressions": {
+                        "content": {
+                            "constant_value": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"DenyAllExceptList\",\n      \"Effect\": \"Deny\",\n      \"NotAction\": [\n        \"organizations:List*\",\n        \"organizations:Describe*\"\n      ],\n      \"NotResource\": \"*\"\n    }\n  ]\n}\n"
+                        },
+                        "description": {
+                            "constant_value": "This is a demo Service Control Policy"
+                        },
+                        "name": {
+                            "constant_value": "demo-scp"
+                        },
+                        "type": {
+                            "constant_value": "SERVICE_CONTROL_POLICY"
+                        }
+                    },
+                    "schema_version": 0
+                }
+            ]
+        }
+    },
+    "timestamp": "2025-05-14T14:49:47Z",
+    "applyable": true,
+    "complete": true,
+    "errored": false
+}

--- a/iam_check/test/test_accessAnalyzer.py
+++ b/iam_check/test/test_accessAnalyzer.py
@@ -27,6 +27,17 @@ class TestAccessAnalyzer:
             == findings
         )
 
+    def test_a2_scp_validation(self):
+        file = _load_json_file("test/scp/test_plan.json")
+        plan = TerraformPlan(**file)
+        check = Validator("123456789012", "us-west-2", "aws")
+        check.run(plan)
+        findings = _load_json_file("test/scp/findings.json")
+        assert (
+            Reporter(None, ["ERROR"], None).build_report_from(check.findings).to_json()
+            == findings
+        )
+
     def test_a2_policy_check_no_new_access_mixed_policies(self):
         for dir_name in ["multiple_policies", "role_inline_assume_policy"]:
             file = _load_json_file(f"test/{dir_name}/test_plan.json")
@@ -98,8 +109,9 @@ class TestAccessAnalyzer:
     def test_a2_check_no_access_granted_actions(self):
         file = _load_json_file("test/no_access_granted/test_plan.json")
         plan = TerraformPlan(**file)
-        check = AccessChecker("us-west-2", ["s3:ListBucket"], None)
+        check = AccessChecker("eu-west-2", ["s3:ListBucket"], None)
         check.run(plan)
+        print(check.findings)
         findings = _load_json_file("test/no_access_granted/actions_findings.json")
         assert (
             Reporter(None, ["ERROR", "SECURITY_WARNING"], None)

--- a/iam_check/test/test_accessAnalyzer.py
+++ b/iam_check/test/test_accessAnalyzer.py
@@ -109,7 +109,7 @@ class TestAccessAnalyzer:
     def test_a2_check_no_access_granted_actions(self):
         file = _load_json_file("test/no_access_granted/test_plan.json")
         plan = TerraformPlan(**file)
-        check = AccessChecker("eu-west-2", ["s3:ListBucket"], None)
+        check = AccessChecker("us-west-2", ["s3:ListBucket"], None)
         check.run(plan)
         print(check.findings)
         findings = _load_json_file("test/no_access_granted/actions_findings.json")


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- Adds support for `aws_organization_policy` resource, also known as `SERVICE_CONTROL_POLICY`
- Add test for scp validation
- Fix finding responses of tests `no_access_granted` since they were different from what the assertion checks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
